### PR TITLE
Update docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ adaptations to make it work with [Trino](https://trino.io/) SQL compute engine.
 
 ### Compatibility
 
-This dbt plugin has been tested against `trino` version `361`.
+This dbt plugin has been tested against `trino` version `362`.
 
 ### Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3.5'
+version: "3.5"
 services:
   trino:
     ports:
       - "8080:8080"
-    image: 'trinodb/trino:361'
+    image: "trinodb/trino:362"
     volumes:
       - ./docker/trino/etc:/usr/lib/trino/etc:ro
       - ./docker/trino/catalog:/etc/trino/catalog

--- a/docker/Dockerfile.util
+++ b/docker/Dockerfile.util
@@ -1,9 +1,7 @@
-FROM openjdk:16-ea-17
+FROM alpine:3.14
 
-RUN apt-get update && \
-  apt-get install -yf postgresql-client netcat && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk add --update netcat-openbsd && \
+  rm -rf /var/cache/apk/*
 
 COPY wait_for_up.bash /bin/wait_for_up
 RUN chmod +x /bin/wait_for_up

--- a/docker/trino/etc/jvm.config
+++ b/docker/trino/etc/jvm.config
@@ -8,5 +8,6 @@
 -XX:+UseGCOverheadLimit
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=256M
+-XX:-OmitStackTraceInFastThrow
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000

--- a/docker/wait_for_up.bash
+++ b/docker/wait_for_up.bash
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 HOST=$1
 PORT=$2
 TIMEOUT=${3:-3}
 [[ -z $HOST ]] && exit 1
 [[ -z $PORT ]] && exit 1
 
-for (( counter=1; counter<$TIMEOUT; counter++ )); do
+for run in {1..$TIMEOUT}; do
     nc -z $HOST $PORT
-    [[ $? -eq 0 ]] && exit 0;
+    [[ $? -eq 0 ]] && exit 0
     sleep 10
 done
 
 nc -z $HOST $PORT
-[[ $? -eq 0 ]] && exit 0;
+[[ $? -eq 0 ]] && exit 0
 
 echo "$HOST:$PORT was not open after $TIMEOUT connection attempts"
 exit 1


### PR DESCRIPTION
Commit: https://github.com/findinpath/dbt-trino/commit/e5f1096d902592640a1e048265870f1e1d056b4d introduces changes which caused docker image to fail during building.

There is a small commit which adds recommended flag for JVM config.  